### PR TITLE
enabling the apache module remoteip

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -51,6 +51,8 @@ RUN sed -i \
   -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
   /etc/apache2/conf-available/security.conf
 
+RUN a2enmod remoteip
+
 RUN apt-get update -y \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
enabling the apache module remoteip will partly fix issue #2 

Besides this change, we should probably have some documentation stating how to create a `remoteip.conf` file which should be bind mounted at /etc/apache2/mods-enabled.

Contents should be something like: 

```
RemoteIPHeader X-Forwarded-For
```

It is also entirely possible to bind mount another text file named `remoteip.load` with this content

```
LoadModule remoteip_module /usr/lib/apache2/modules/mod_remoteip.so
```

If that is done, then we don't even need this merge request.


But we still need some documentation stating how to do it