### PR TITLE
Bullseye update

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,8 +5,8 @@ FROM ${ARCH}php:%PHP_BASE_IMAGE%
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION %DOLI_VERSION%
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:7.4-apache-buster
+FROM ${ARCH}php:7.4-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 15.0.3
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.1-apache-buster
+FROM ${ARCH}php:8.1-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 16.0.5
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.1-apache-buster
+FROM ${ARCH}php:8.1-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 17.0.4
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.1-apache-buster
+FROM ${ARCH}php:8.1-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 18.0.6
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.2-apache-buster
+FROM ${ARCH}php:8.2-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 19.0.4
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/20.0.2-php8.2/Dockerfile
+++ b/images/20.0.2-php8.2/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.2-apache-buster
+FROM ${ARCH}php:8.2-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION 20.0.2
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
 
 # Use an image like PHP_BASE_IMAGE=x.y-apache-buster
-FROM ${ARCH}php:8.2-apache-buster
+FROM ${ARCH}php:8.2-apache-bullseye
 
 # Credit/Initial maintainer: Garcia MICHEL <garcia@soamichel.fr>
 # Modified according to the GPL license by developers of the Dolibarr community:
-# 2024 Alois Micard 
-# 2024 Laurent Destailleur 
+# 2024 Alois Micard
+# 2024 Laurent Destailleur
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION develop
@@ -59,6 +59,7 @@ RUN apt-get update -y \
         libjpeg62-turbo-dev \
         libkrb5-dev \
         libldap2-dev \
+        libldap-common \
         libpng-dev \
         libpq-dev \
         libxml2-dev \

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 #
 # Run this script to generate all files found into images directory, used for each image.
 # The source files are the files into the root.
-# 
+#
 
 set -e
 
@@ -36,11 +36,11 @@ for dolibarrVersion in "${DOLIBARR_VERSIONS[@]}"; do
   # Mapping PHP version according to Dolibarr version (See https://wiki.dolibarr.org/index.php/Versions)
   # Regarding PHP Supported version : https://www.php.net/supported-versions.php
   if [ "${dolibarrVersion}" = "develop" ] || [ "${dolibarrMajor}" -ge "19" ] || [ "${dolibarrMajor}" -ge "20" ] || [ "${dolibarrMajor}" -ge "21" ]; then
-    php_base_images=( "8.2-apache-buster" )
+    php_base_images=( "8.2-apache-bullseye" )
   elif [ "${dolibarrMajor}" -ge "16" ]; then
-    php_base_images=( "8.1-apache-buster" )
+    php_base_images=( "8.1-apache-bullseye" )
   else
-    php_base_images=( "7.4-apache-buster" )
+    php_base_images=( "7.4-apache-bullseye" )
   fi
 
   for php_base_image in "${php_base_images[@]}"; do


### PR DESCRIPTION
The Buster-based images have currently a lot of vulnerabilities, as Buster is EOL since 4 months. This PR updates the base images to Bullseye.

In Bullseye, `libldap-common` is no longer a dependency of `libldap2-dev`,  but it's still required for LDAPS connections, so I added it explicitly.

I'm using the new v18 image on prod, everything seems fine for the moment, but more testing would be welcome to be sure I didn't break anything.

I also ran tests locally with `test.sh`, on a Debian 11 host with Docker 27.3.1 and Compose v2:

* `./test.sh 15.0.3 7.4`:  [15.0.3_php7.4.log](https://github.com/user-attachments/files/17575983/15.0.3_php7.4.log)
* `./test.sh 16.0.5 8.1`: [16.0.5_php8.1.log](https://github.com/user-attachments/files/17575985/16.0.5_php8.1.log)
* `./test.sh 17.0.4 8.1`: [17.0.4_php8.1.log](https://github.com/user-attachments/files/17575987/17.0.4_php8.1.log)
* `./test.sh 18.0.5 8.1`: [18.0.5_php8.1.log](https://github.com/user-attachments/files/17576018/18.0.5_php8.1.log)

(The remaining tests are in progress)

After each test, the `docker compose up` stays in the foreground, so I exit with `Ctrl` + `C`. Then, I clean up manually with `docker compose down && rm -r .volumes`.

In all tests, the web UI and login are working. There is an error with the `cron` container, but it's unrelated to this PR:

```
cron-1  | ***** cron_run_jobs.php (16.0.5) pid=41 ***** userlogin=admintest ***** 2024-10-30T13:55:01Z *****
cron-1  | Error: securitykey is wrong
```

There are also PHP warnings that seem unrelated.

Note: my second commit fixes a permission error that I got during testing.
