### PR TITLE
fix: change owner after initialization

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/18.0.6-php8.1/docker-run.sh
+++ b/images/18.0.6-php8.1/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/19.0.4-php8.2/docker-run.sh
+++ b/images/19.0.4-php8.2/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/20.0.2-php8.2/docker-run.sh
+++ b/images/20.0.2-php8.2/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -32,11 +32,6 @@ function get_env_value() {
 # Function to create directories, create conf.php file and set permissions on files
 function initDolibarr()
 {
-  local CURRENT_UID=$(id -u www-data)
-  local CURRENT_GID=$(id -g www-data)
-  usermod -u ${WWW_USER_ID} www-data
-  groupmod -g ${WWW_GROUP_ID} www-data
-
   if [[ ! -d /var/www/documents ]]; then
     echo "[INIT] => create volume directory /var/www/documents ..."
     mkdir -p /var/www/documents
@@ -108,16 +103,6 @@ EOF
     chmod 600 /var/www/html/conf/conf.php
   else
     chmod 400 /var/www/html/conf/conf.php
-  fi
-
-  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
-    # Refresh file ownership cause it has changed
-    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
-    chown -R www-data:www-data /var/www
-  else
-    # Reducing load on init : change ownership only for volumes declared in docker
-    echo "[INIT] => update ownership for files in /var/www/documents ..."
-    chown -R www-data:www-data /var/www/documents
   fi
 }
 
@@ -416,7 +401,22 @@ function run()
 
   # Run scripts before starting
   runScripts "before-starting.d"
-  
+
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+
   echo "*** You can connect to the docker Mariadb with:"
   echo "sudo docker exec -it nameofmariadbcontainer bash"
   echo "mysql -uroot -p'MYSQL_ROOT_PASSWORD' -h localhost"


### PR DESCRIPTION
## Problem

Currently, the `docker-run.sh` script updates ownership for files in
`/var/www/documents`, but more files get added to that directory after the
ownership update, so the new files may have a bad owner. That causes a broken UI
on `dolibarr/dolibarr:18.0.6`:

![Screenshot 2024-11-14 at 16-59-56 Accueil - Dolibarr 18 0 6](https://github.com/user-attachments/assets/1e561038-6003-4a36-823c-1be6847a2ee3)

To reproduce, use the following `docker-compose.yml`:

```yml
services:
    mariadb:
        image: mariadb:11.4
        environment:
            MYSQL_RANDOM_ROOT_PASSWORD: "1"
            MYSQL_DATABASE: dolidb
            MYSQL_USER: dolibarr
            MYSQL_PASSWORD: demo_password

    web:
        image: dolibarr/dolibarr:18.0.6@sha256:33ebba5024bf229ddef3051d6a1ef63ef44913c60e302d36cc2aad7bfdc4b980
        volumes:
            - ./.volumes/dolibarr/documents:/var/www/documents
        depends_on:
            - mariadb
        environment:
            DOLI_DB_HOST: mariadb
            DOLI_DB_NAME: dolidb
            DOLI_DB_USER: dolibarr
            DOLI_DB_PASSWORD: demo_password
            DOLI_ADMIN_LOGIN: admintest
            DOLI_ADMIN_PASSWORD: admintest
            DOLI_URL_ROOT: 'http://0.0.0.0:8018'
            DOLI_INSTANCE_UNIQUE_ID: myinstanceuniqueid
            DOLI_INIT_DEMO: 1
        ports:
            - "8018:80"
```

Then go to http://localhost:8018 and login with `admintest` / `admintest`.

A `chown -R 33:33 .volumes/dolibarr/documents` fixes the problem, but that's not ideal, as users have to run the command manually.

On `19.0.4`, the UI is OK, but there are some PHP warnings such as:

```
[Thu Nov 14 16:14:07.618739 2024] [php:warn] [pid 3145] [client 172.19.0.1:52118] PHP Warning:  fopen(/var/www/documents/users/temp/FactureStats_getNbByMonthWithPrevYear_supplier_fr_FR_entity.1_user30.cache): Failed to open stream: Permission denied in /var/www/html/core/class/stats.class.php on line 160, referer: http://localhost:8019/
```

On `20.0.2`, the UI is OK, there are no warnings anymore, but there are still many files owned by `root` in `/var/www/documents`

## Fix

This PR moves the code handling the ownership update to a later
point, when all files have been copied to `/var/www/documents`.
