### PR TITLE
Improve CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: build
 on:
-  #push:
-  #    branches:
-  #        - main
   # can run job manually
   workflow_dispatch:
   # Run once a week
@@ -11,6 +8,9 @@ on:
 
 jobs:
   build-docker-images:
+    strategy:
+      matrix:
+        dolibarr_version: [ 15.0.3, 16.0.5, 17.0.4, 18.0.6, 19.0.4, 20.0.4, develop ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
           echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          ./update.sh
+          ./update.sh ${{ matrix.dolibarr_version }}
 
   update-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,11 @@ jobs:
     strategy:
       matrix:
         dolibarr_version: [ 15.0.3, 16.0.5, 17.0.4, 18.0.6, 19.0.4, 20.0.4, develop ]
-    runs-on: ubuntu-22.04
+        os_version: [ ubuntu-24.04, ubuntu-24.04-arm ]
+    runs-on: ${{ matrix.os_version }}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - env:
           DOCKER_BUILD: 1
           DOCKER_PUSH: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-docker-images:
     strategy:
       matrix:
-        dolibarr_version: [ 15.0.3 ]
+        dolibarr_version: [ 15.0.3, 16.0.5, 17.0.4, 18.0.6, 19.0.4, 20.0.4, develop ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - env:
           DOCKER_BUILD: 1
-          DOCKER_PUSH: 1
+          DOCKER_PUSH: 0
         run: |
           echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
           echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - env:
           DOCKER_BUILD: 1
-          DOCKER_PUSH: 0
+          DOCKER_PUSH: 1
         run: |
           echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
           echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,41 +1,41 @@
 name: build
 on:
-    #push:
-    #    branches:
-    #        - main
-    # can run job manually
-    workflow_dispatch:			
-    # Run once a week 
-    schedule:
-        - cron: '0 0 * * 6'
+  #push:
+  #    branches:
+  #        - main
+  # can run job manually
+  workflow_dispatch:
+  # Run once a week
+  schedule:
+    - cron: '0 0 * * 6'
 
 jobs:
-    build-docker-images:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: docker/setup-buildx-action@v2
-            - env:
-                DOCKER_BUILD: 1
-                DOCKER_PUSH: 1
-              run: |
-                echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
-                echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-                ./update.sh
+  build-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - env:
+          DOCKER_BUILD: 1
+          DOCKER_PUSH: 1
+        run: |
+          echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
+          echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          ./update.sh
 
-    update-readme:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - run: |
-                echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }} 
-                docker run --rm -t \
-                -v $(pwd):/src \
-                -e DOCKER_USER=${{ secrets.DOCKER_HUB_USERNAME }} \
-                -e DOCKER_PASS=${{ secrets.DOCKER_HUB_PASSWORD }} \
-                -e PUSHRM_PROVIDER=dockerhub \
-                -e PUSHRM_FILE=/src/README.md \
-                -e PUSHRM_SHORT='Docker image for Dolibarr ERP CRM Open source web suite.' \
-                -e PUSHRM_TARGET=docker.io/dolibarr/dolibarr \
-                -e PUSHRM_DEBUG=1 \
-                chko/docker-pushrm:1
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }} 
+          docker run --rm -t \
+          -v $(pwd):/src \
+          -e DOCKER_USER=${{ secrets.DOCKER_HUB_USERNAME }} \
+          -e DOCKER_PASS=${{ secrets.DOCKER_HUB_PASSWORD }} \
+          -e PUSHRM_PROVIDER=dockerhub \
+          -e PUSHRM_FILE=/src/README.md \
+          -e PUSHRM_SHORT='Docker image for Dolibarr ERP CRM Open source web suite.' \
+          -e PUSHRM_TARGET=docker.io/dolibarr/dolibarr \
+          -e PUSHRM_DEBUG=1 \
+          chko/docker-pushrm:1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         dolibarr_version: [ 15.0.3, 16.0.5, 17.0.4, 18.0.6, 19.0.4, 20.0.4, develop ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -24,7 +24,7 @@ jobs:
           ./update.sh ${{ matrix.dolibarr_version }}
 
   update-readme:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           ./update.sh ${{ matrix.dolibarr_version }}
 
   update-readme:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - env:
           DOCKER_BUILD: 1
-          DOCKER_PUSH: 0
+          DOCKER_PUSH: 1
         run: |
           echo secrets.DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
           echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
           ./update.sh ${{ matrix.dolibarr_version }}
 
   update-readme:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-docker-images:
     strategy:
       matrix:
-        dolibarr_version: [ 15.0.3, 16.0.5, 17.0.4, 18.0.6, 19.0.4, 20.0.4, develop ]
+        dolibarr_version: [ 15.0.3 ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           run: echo "The diff after running the update.sh shows that the update.sh was not run before commiting the PR."
 
     check-build:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v3
             - env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           run: echo "The diff after running the update.sh shows that the update.sh was not run before commiting the PR."
 
     check-build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See https://hub.docker.com/r/dolibarr/dolibarr/tags
 
 ## Supported architectures
 
-Linux x86-64 (`amd64`), ARMv7 32-bit (`arm32v7` :warning: MariaDB/Mysql docker images don't support it) and ARMv8 64-bit (`arm64v8`)
+Linux x86-64 (`amd64`) and ARMv8 64-bit (`arm64v8`).
 
 
 ## How to run this image ?

--- a/update.sh
+++ b/update.sh
@@ -11,7 +11,14 @@ DOCKER_PUSH=${DOCKER_PUSH:-0}
 
 BASE_DIR="$( cd "$(dirname "$0")" && pwd )"
 
-source "${BASE_DIR}/versions.sh"
+# If a target version is provided to the build script, only build this one
+# otherwise fallback to previous logic and build versions defined in ./versions.sh script
+if [ -z "$1" ]
+  then
+    source "${BASE_DIR}/versions.sh"
+else
+  DOLIBARR_VERSIONS=("$1")
+fi
 
 tags=""
 

--- a/update.sh
+++ b/update.sh
@@ -27,12 +27,6 @@ if [ -f "${BASE_DIR}/images/README.md" ]; then
 fi
 rm -rf "${BASE_DIR}/images" "${BASE_DIR}/docker-compose-links"
 
-if [ "${DOCKER_BUILD}" = "1" ] && [ "${DOCKER_PUSH}" = "1" ]; then
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  docker buildx create --driver docker-container --use
-  docker buildx inspect --bootstrap
-fi
-
 for dolibarrVersion in "${DOLIBARR_VERSIONS[@]}"; do
   echo "Generate Dockerfile for Dolibarr ${dolibarrVersion}"
 
@@ -91,13 +85,11 @@ for dolibarrVersion in "${DOLIBARR_VERSIONS[@]}"; do
         docker buildx build \
           --push \
           --compress \
-          --platform linux/arm/v7,linux/arm64,linux/amd64 \
           ${buildOptionTags} \
           "${dir}"
       else
         docker build \
           --compress \
-          --platform linux/arm/v7,linux/arm64,linux/amd64 \
           ${buildOptionTags} \
           "${dir}"
       fi

--- a/update.sh
+++ b/update.sh
@@ -11,14 +11,13 @@ DOCKER_PUSH=${DOCKER_PUSH:-0}
 
 BASE_DIR="$( cd "$(dirname "$0")" && pwd )"
 
+source "${BASE_DIR}/versions.sh"
+
 # If a target version is provided to the build script, only build this one
-# otherwise fallback to previous logic and build versions defined in ./versions.sh script
-if [ -z "$1" ]
-  then
-    source "${BASE_DIR}/versions.sh"
-else
-  DOLIBARR_VERSIONS=("$1")
-fi
+ if [ "$#" -eq  "1" ]
+   then
+     DOLIBARR_VERSIONS=("$1")
+ fi
 
 tags=""
 

--- a/update.sh
+++ b/update.sh
@@ -97,6 +97,7 @@ for dolibarrVersion in "${DOLIBARR_VERSIONS[@]}"; do
       else
         docker build \
           --compress \
+          --platform linux/arm/v7,linux/arm64,linux/amd64 \
           ${buildOptionTags} \
           "${dir}"
       fi


### PR DESCRIPTION
**Disclaimer**: This is a draft pull request. Not to be merged because I need to clean some things first.

---

This PR aims to improve the CI/CD process of this GitHub actions. Here are the following changes :

- Use GitHub [matrix strategies](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow) in order to parallelize the build process and reduce build time. We are now down to ~5mins for a complete build process.
- Switch the multi platform image build from using emulation (with QEMU) to using host runner capabilities. If we want to build **for** arm64, we build **on** arm64. This reduce build time as well but since GitHub does not provide armv7 runners (yet) it means we will drop support on armv7 moving forward.