### PR TITLE
Update README.md DOLI_ENABLE_MODULES need COMPANY_NAME and CONTRYCODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can use the following variables for a better customization of your docker-co
 | **DOLI_URL_ROOT**               | *http://localhost*             | Url root of the Dolibarr installation
 | **DOLI_ADMIN_LOGIN**            | *admin*                        | Admin's login created on the first boot
 | **DOLI_ADMIN_PASSWORD**         | *admin*                        | Admin's initial password created on the first boot
-| **DOLI_ENABLE_MODULES**         |                                | Comma-separated list of modules to be activated at install. modUser will always be activated. (Ex: `Societe,Facture,Stock`)
+| **DOLI_ENABLE_MODULES**         |                                | Comma-separated list of modules to be activated at install. modUser will always be activated. (Ex: `Societe,Facture,Stock`). Modules can't be activated correctly if DOLI_COMPANY_NAME and DOLI_COMPANY_COUNTRYCODE are not set
 | **DOLI_COMPANY_NAME**           |                                | Set the company name of Dolibarr at container init
 | **DOLI_COMPANY_COUNTRYCODE**    |                                | Set the company and Dolibarr country at container init. Need 2-letter codes like "FR", "GB", "US",...
 | **DOLI_AUTH**                   | *dolibarr*                     | Which method is used to connect users, change to `ldap` or `ldap, dolibarr` to use LDAP


### PR DESCRIPTION
As i recall when i implement DOLI_ENABLE_MODULES, it is really bad idea to enable modules without having set up the company name (DOLI_COMPANY_NAME) and country (DOLI_COMPANY_COUNTRYCODE) before anything else.
And so updating the documentation to reflect this.