### PR TITLE
disable apache cgi-bin because dolibarr doesn't seem to use it

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update -y \
         vim-tiny \
         cron \
     && apt-get autoremove -y \
+    && a2disconf serve-cgi-bin \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip opcache tidy \
     && docker-php-ext-configure pgsql -with-pgsql \


### PR DESCRIPTION
disable apache cgi-bin because dolibarr doesn't seem to use it and then the container should not have it by default