### PR TITLE
2 new environment variables to control apache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ You can use the following variables for a better customization of your docker-co
 | **DOLI_CRON_KEY**               |                                | Security key launch cron jobs
 | **DOLI_CRON_USER**              |                                | Dolibarr user used for cron jobs
 | **DOLI_INSTANCE_UNIQUE_ID**     |                                | Secret ID used as a salt / key for some encryption. By default, it is set randomly when the docker container is created.
+| **APACHE_REMOTEIP_CONF**	  | empty or variable not set	   | If this variable is set and it is not empty, then the full contents of this variable will be echoed to /etc/apache2/mods-available/remoteip.conf and then a2enmod remoteip will be run
+| **APACHE_MODULES**		  | empty or variable not set	   | If this variable is set and not empty, then all the apache modules in this variable will be installed using a2enmod. Apache module names should be separated by a single space character.
+
 
 Some environment variables are compatible with docker secrets behaviour, just add the `_FILE` suffix to var name and point the value file to read.
 Environment variables that are compatible with docker secrets:
@@ -266,6 +269,8 @@ Mountpoint: "/etc/apache2/conf-enabled/servername.conf"
 read-only: Yes, mount it read only with :ro 
 
 #### Running your dolibarr behind a proxy?
+
+This section describes the old method, consider using the environment variable APACHE_REMOTEIP_CONF which is less work.
 
 If you want Dolibarr or the logs from the dolibarr container to reveal the original IP address and not just the proxy's IP address you should create 2 text files:
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/18.0.6-php8.1/docker-run.sh
+++ b/images/18.0.6-php8.1/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/19.0.4-php8.2/docker-run.sh
+++ b/images/19.0.4-php8.2/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/20.0.4-php8.2/docker-run.sh
+++ b/images/20.0.4-php8.2/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/21.0.0-php8.2/docker-run.sh
+++ b/images/21.0.0-php8.2/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -480,6 +480,15 @@ if [[ ${DOLI_CRON} -eq 1 ]]; then
     exit 0
 fi
 
+if [[ "" != "${APACHE_REMOTEIP_CONF}" ]]; then
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/mods-available/remoteip.conf
+    a2enmod remoteip
+fi
+
+for A2MOD in ${APACHE_MODULES}; do
+    a2enmod ${A2MOD}
+done
+
 if [ "${1#-}" != "$1" ]; then
   set -- apache2-foreground "$@"
 fi


### PR DESCRIPTION
This PR introduces 2 new environment variables that will control apaches configuration. The changes happens at the very end of docker-run.sh just before apache is started.

APACHE_REMOTEIP_CONF configures apaches remote ip module for which header it should consider for knowing the true remote ip. Useful if you have a proxy server in front of your dolibarr. If this variable is set, and not empty, then it will also enable the remoteip module - because if you set the configuration, surely you want it enabled.

APACHE_MODULES is supposed to be a single space character separated list of apache modules that you want enabled. It will just for loop through the list and a2enmod them one by one. Order may matter if modules depends on other modules.

If you want remoteip module enabled, but not configured you can use this environment variable to enable it in apache.