### PR TITLE
Docker Compose with cron example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ able to access the Dolibarr using the URL http://0.0.0.0:xx
 Other examples:
 
 You can find several examples in the `examples` directory, such as:
+ - [Running Dolibarr with cron (for Scheduled Tasks module)](./examples/with-cron/dolibarr-with-cron.md)
  - [Running Dolibarr with a letsencrypt certificate](./examples/with-certbot/dolibarr-with-certbot.md)
  - [Running Dolibarr with a mysql server](./examples/with-mysql/dolibarr-with-mysql.md)
  - [Running Dolibarr with a Traefik reverse proxy](./examples/with-rp-traefik/dolibarr-with-traefik.md)

--- a/examples/with-cron/docker-compose.yml
+++ b/examples/with-cron/docker-compose.yml
@@ -1,0 +1,109 @@
+x-dolibarr: &dolibarr
+  image: dolibarr/dolibarr:latest # Change the tag to your Dolibarr version
+  # Limiting the container's resources isn't mandatory, but it's recommended.
+  # Adjust for what is feasible for your setup
+  deploy:
+    resources:
+      limits:
+        cpus: '1'
+        memory: 512M
+      reservations:
+        cpus: '0.2'
+        memory: 32M
+  volumes:
+    - custom:/var/www/html/custom
+    - documents:/var/www/documents
+  restart: unless-stopped
+
+volumes:
+  custom:
+  documents:
+  db:
+
+networks:
+  internal-pod:
+  external-pod:
+
+services:
+  db:
+    image: mariadb:lts
+    # Limiting the container's resources isn't mandatory, but it's recommended.
+    # Adjust for what is feasible for your setup
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.2'
+          memory: 32M
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 60s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      MYSQL_DATABASE: ${DOLI_DB_NAME:-dolidb}
+      MYSQL_USER: ${DOLI_DB_USER:-dolidbuser}
+      MYSQL_PASSWORD: ${DOLI_DB_PASSWORD:-dolidbpass}
+      MYSQL_ROOT_PASSWORD: "mysupersupersecretpasswordforrootuser"
+    volumes:
+      - db:/var/lib/mysql
+    networks:
+      - internal-pod
+
+  app:
+    <<: *dolibarr
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      start_period: 300s
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      WWW_USER_ID: ${WWW_USER_ID:-1000}
+      WWW_GROUP_ID: ${WWW_GROUP_ID:-1000}
+      DOLI_DB_HOST: db
+      DOLI_DB_NAME: ${DOLI_DB_NAME:-dolidb}
+      DOLI_DB_USER: ${DOLI_DB_USER:-dolidbuser}
+      DOLI_DB_PASSWORD: ${DOLI_DB_PASSWORD:-dolidbpass}
+      DOLI_URL_ROOT: "${DOLI_URL_ROOT:-http://0.0.0.0}"
+      DOLI_ADMIN_LOGIN: "${DOLI_ADMIN_LOGIN:-admin}"
+      DOLI_ADMIN_PASSWORD: "${DOLI_ADMIN_PASSWORD:-admin}"
+      DOLI_CRON: 0
+      DOLI_CRON_USER: "${DOLI_ADMIN_PASSWORD:-admin}"
+      DOLI_CRON_KEY: ${DOLI_CRON_KEY:-mycronsecurekey}
+      DOLI_INIT_DEMO: ${DOLI_INIT_DEMO:-0}
+      DOLI_COMPANY_NAME: ${DOLI_COMPANY_NAME:-MyBigCompany}
+    ports:
+      - 80:80
+    networks:
+      - internal-pod
+      - external-pod
+
+  cron:
+    <<: *dolibarr
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      WWW_USER_ID: ${WWW_USER_ID:-1000}
+      WWW_GROUP_ID: ${WWW_GROUP_ID:-1000}
+      DOLI_DB_HOST: db
+      DOLI_DB_NAME: ${DOLI_DB_NAME:-dolidb}
+      DOLI_DB_USER: ${DOLI_DB_USER:-dolidbuser}
+      DOLI_DB_PASSWORD: ${DOLI_DB_PASSWORD:-dolidbpass}
+      DOLI_URL_ROOT: "${DOLI_URL_ROOT:-http://0.0.0.0}"
+      DOLI_ADMIN_LOGIN: "${DOLI_ADMIN_LOGIN:-admin}"
+      DOLI_ADMIN_PASSWORD: "${DOLI_ADMIN_PASSWORD:-admin}"
+      DOLI_CRON: 1
+      DOLI_CRON_USER: "${DOLI_ADMIN_PASSWORD:-admin}"
+      DOLI_CRON_KEY: ${DOLI_CRON_KEY:-mycronsecurekey}
+      DOLI_INIT_DEMO: ${DOLI_INIT_DEMO:-0}
+      DOLI_COMPANY_NAME: ${DOLI_COMPANY_NAME:-MyBigCompany}
+    networks:
+      - internal-pod

--- a/examples/with-cron/dolibarr-with-cron.md
+++ b/examples/with-cron/dolibarr-with-cron.md
@@ -1,0 +1,3 @@
+# Dolibarr with cron
+
+To ensure that the "Scheduled Tasks" module works properly, it's essential to enable cron on the Dolibarr container. This requires two Dolibarr instances: the primary Dolibarr container and an additional container dedicated solely to running cron jobs. Use the provided `docker-compose.yml` to easily set up this architecture.


### PR DESCRIPTION
Following Issue #44, I've created a Docker Compose example that includes a functional cron setup to better guide future users on how to get everything working properly.