### PR TITLE
making documents/api/temp and ensuring that the webserver can write in it

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -96,6 +96,7 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom
+RUN mkdir -p /var/www/documents/api/temp && chown -R www-data:www-data /var/www/documents/api/
 
 COPY docker-init.php /var/www/scripts/
 COPY docker-run.sh /usr/local/bin/


### PR DESCRIPTION
When trying to use the API explorer in v21.0.0 I got this error

```
Erreur temp dir api/temp not writable
```
The container log revealed that it was trying to write in documents/api/temp.

**FLAW** in this method is that if you mount a directory on top of the documents path, then it probably most like will not have the api/temp directory.

**Solution** to that could be to move this into docker-run.sh

**better solution** that the API explorer message is full path, and/or that when you enable the API in setup, then it checks if this folder is writeable, and possibly complains if it is not