### PR TITLE
securing apache/dolibarr installation by letting apache deny access

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/apache-conf-enabled/deny-certificates.conf
+++ b/apache-conf-enabled/deny-certificates.conf
@@ -1,0 +1,64 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+

--- a/apache-conf-enabled/deny-compressed-files.conf
+++ b/apache-conf-enabled/deny-compressed-files.conf
@@ -1,0 +1,24 @@
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+

--- a/apache-conf-enabled/deny-csv.conf
+++ b/apache-conf-enabled/deny-csv.conf
@@ -1,0 +1,3 @@
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-dolibarr-conf.conf
+++ b/apache-conf-enabled/deny-dolibarr-conf.conf
@@ -1,0 +1,7 @@
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-dolibarr-langs.conf
+++ b/apache-conf-enabled/deny-dolibarr-langs.conf
@@ -1,0 +1,7 @@
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-dotfiles.conf
+++ b/apache-conf-enabled/deny-dotfiles.conf
@@ -1,0 +1,4 @@
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+

--- a/apache-conf-enabled/deny-git.conf
+++ b/apache-conf-enabled/deny-git.conf
@@ -1,0 +1,8 @@
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-json.conf
+++ b/apache-conf-enabled/deny-json.conf
@@ -1,0 +1,3 @@
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-sql.conf
+++ b/apache-conf-enabled/deny-sql.conf
@@ -1,0 +1,3 @@
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-svn.conf
+++ b/apache-conf-enabled/deny-svn.conf
@@ -1,0 +1,3 @@
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>

--- a/apache-conf-enabled/deny-xml.conf
+++ b/apache-conf-enabled/deny-xml.conf
@@ -1,0 +1,3 @@
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>

--- a/apache-conf-enabled/deny-yml.conf
+++ b/apache-conf-enabled/deny-yml.conf
@@ -1,0 +1,3 @@
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/15.0.3-php7.4/apache-deny.conf
+++ b/images/15.0.3-php7.4/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/16.0.5-php8.1/apache-deny.conf
+++ b/images/16.0.5-php8.1/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/17.0.4-php8.1/apache-deny.conf
+++ b/images/17.0.4-php8.1/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/18.0.6-php8.1/apache-deny.conf
+++ b/images/18.0.6-php8.1/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/19.0.4-php8.2/apache-deny.conf
+++ b/images/19.0.4-php8.2/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/20.0.4-php8.2/apache-deny.conf
+++ b/images/20.0.4-php8.2/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/21.0.0-php8.2/apache-deny.conf
+++ b/images/21.0.0-php8.2/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -81,6 +81,15 @@ RUN apt-get update -y \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
+# Disable useless Apache modules to provide safe defaults
+RUN a2disconf serve-cgi-bin \
+    && a2dismod status \
+    && a2dismod -f alias \
+    && a2dismod -f autoindex \
+    && rm -rf /etc/apache2/mods-enabled/dir.conf
+COPY apache-deny.conf /etc/apache2/conf-enabled/deny.conf
+RUN apache2ctl configtest
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/develop/apache-deny.conf
+++ b/images/develop/apache-deny.conf
@@ -1,0 +1,132 @@
+<FilesMatch "/\.cer">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.crt">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.cert">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pem">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.der">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.key">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.keystore">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.jks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p12">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pcks">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.ca-bundle">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7b">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7c">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p7s">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.pfx">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.p8">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.gz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tgz">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.tar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.zip">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.bz2">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.rar">
+   Require all denied
+</FilesMatch>
+
+<FilesMatch "/\.csv">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/conf/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/conf\.php">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/langs/">
+   Require all denied
+</DirectoryMatch>
+
+<FilesMatch "/\.lang">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/^\.">
+   Require all denied
+</FilesMatch>
+
+<DirectoryMatch "/\.git">
+   Require all denied
+</DirectoryMatch>
+
+# should catch .gitignore .gitattributes
+<FilesMatch "/^\.git">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.json">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.sql">
+   Require all denied
+</FilesMatch>
+<DirectoryMatch "/\.svn">
+   Require all denied
+</DirectoryMatch>
+<FilesMatch "/\.xml">
+   Require all denied
+</FilesMatch>
+<FilesMatch "/\.yml">
+   Require all denied
+</FilesMatch>

--- a/update.sh
+++ b/update.sh
@@ -86,6 +86,7 @@ for dolibarrVersion in "${DOLIBARR_VERSIONS[@]}"; do
 
     cp -a "${BASE_DIR}/docker-init.php" "${dir}/docker-init.php"
     cp -a "${BASE_DIR}/docker-run.sh" "${dir}/docker-run.sh"
+    cat apache-conf-enabled/*.conf > "${dir}/apache-deny.conf"
 
     if [ "${DOCKER_BUILD}" = "1" ]; then
       if [ "${DOCKER_PUSH}" = "1" ]; then


### PR DESCRIPTION
securing apache/dolibarr installation by letting apache deny access to lots of file types and some directories we can probably safely deny access to

Related to TALK https://github.com/Dolibarr/dolibarr-docker/issues/53