### PR TITLE
Generate unique value for DOLI_INSTANCE_UNIQUE_ID

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,33 @@
+name: update
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to work on'
+        required: true
+        default: 'patch-1'
+        type: string
+
+jobs:
+  build-docker-images:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+          fetch-depth: 0  # Important pour pouvoir pousser ensuite
+
+      - name: Run update script
+        env:
+          DOCKER_BUILD: 0
+          DOCKER_PUSH: 0
+        run: |
+          ./update.sh
+      - name: Force Git to detect changes
+        run: |
+          git add -f images/
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update generated Dockerfiles" || echo "No changes to commit"
+          git push origin ${{ github.event.inputs.target_branch }}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/18.0.6-php8.1/docker-run.sh
+++ b/images/18.0.6-php8.1/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/19.0.4-php8.2/docker-run.sh
+++ b/images/19.0.4-php8.2/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/20.0.4-php8.2/docker-run.sh
+++ b/images/20.0.4-php8.2/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/21.0.0-php8.2/docker-run.sh
+++ b/images/21.0.0-php8.2/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -73,9 +73,10 @@ EOF
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php
     else
-      # It is better to have a generic value than no value
+      # Generate random string 
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
-      echo "\$dolibarr_main_instance_unique_id='myinstanceuniquekey';" >> /var/www/html/conf/conf.php
+      instanceid=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25)
+      echo "\$dolibarr_main_instance_unique_id='${instanceid}';" >> /var/www/html/conf/conf.php
     fi
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
       echo "[INIT] => update Dolibarr Config with LDAP entries ..."


### PR DESCRIPTION
Documentation say that DOLI_INSTANCE_UNIQUE_ID "By default, it is set randomly when the docker container is created."

It is not the case before this PR.
This PR aim to create a 25 characters length random string at creation of conf/conf.php.

This value change at every container recreation (with no other impact than the need for users to re-authenticate, it seems), so if someone would want to keep the same value, they should set the DOLI_INSTANCE_UNIQUE_ID variable.

In order to do this PR, i've created a github workflow working on the "patch-1" branch to execute the update.sh. 
This workflow is only manually executed so there is no risk.