### PR TITLE
[Security] Fix Information Disclosure vulnerability

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' /usr/local/etc/php/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/21.0.0-php8.2/Dockerfile
+++ b/images/21.0.0-php8.2/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
-    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
+    && sed -i 's/expose_php = On/expose_php = Off/g' ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
 
 # Get Dolibarr


### PR DESCRIPTION
This PR addresses an information disclosure vulnerability originating from PHP's base image. This vulnerability exposes the PHP version through an X-Powered-By header, which attackers could exploit to fingerprint the server and identify potential weaknesses.

# Scoring and Classification
- CVSS 3.1: 5.3 ([AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N&version=3.1](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N&version=3.1)
- OWASP Top 10: [A05:2021](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/)
- Common Weakness Enumeration: [CWE-497](https://cwe.mitre.org/data/definitions/497.html)

# Tested Versions (Docker Tags)
- 21 (digest 6e25432fdd7c)
- 20 (digest 2d75614683b5)

# Mitigation
The mitigation is relatively simple: it requires changing the `expose_php` variable from "On" to "Off" in the file located at `/usr/local/etc/php/php.ini`.

**Note:** I opted to create a PR directly, without following the Guidelines announced on the main Dolibarr repository, because this isn't a vulnerability from Dolibarr itself. This is also a very trivial vulnerability, and I suppose that attributing a CVE to it would be complex and unnecessary.