### PR TITLE
MySQL TLS connection

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,6 +7,7 @@ FROM ${ARCH}php:%PHP_BASE_IMAGE%
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=%DOLI_VERSION%
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:7.4-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=15.0.3
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.1-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=16.0.5
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.1-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=17.0.4
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/18.0.6-php8.1/Dockerfile
+++ b/images/18.0.6-php8.1/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.1-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=18.0.6
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/18.0.6-php8.1/docker-run.sh
+++ b/images/18.0.6-php8.1/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.2-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=19.0.4
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/19.0.4-php8.2/docker-run.sh
+++ b/images/19.0.4-php8.2/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.2-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=20.0.4
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/20.0.4-php8.2/docker-run.sh
+++ b/images/20.0.4-php8.2/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/21.0.1-php8.2/Dockerfile
+++ b/images/21.0.1-php8.2/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.2-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=21.0.1
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/21.0.1-php8.2/docker-run.sh
+++ b/images/21.0.1-php8.2/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -7,6 +7,7 @@ FROM ${ARCH}php:8.2-apache-bullseye
 # Modified according to the GPL license by developers of the Dolibarr community:
 # 2024 Alois Micard
 # 2024 Laurent Destailleur
+# 2025 Renato de Castro Ferreira
 LABEL maintainer="The Dolibarr foundation <contact@dolibarr.org>"
 
 ENV DOLI_VERSION=develop
@@ -18,6 +19,7 @@ ENV DOLI_DB_TYPE=mysqli
 ENV DOLI_DB_HOST=mysql
 ENV DOLI_DB_HOST_PORT=3306
 ENV DOLI_DB_NAME=dolidb
+ENV DOLI_DB_SSL=true
 
 ENV DOLI_URL_ROOT='http://localhost'
 ENV DOLI_NOCSRFCHECK=0

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -59,7 +59,16 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_url_root_alt='/custom';
 \$dolibarr_main_document_root_alt='/var/www/html/custom';
 \$dolibarr_main_data_root='/var/www/documents';
-\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+EOF
+
+    # Check if SSL is enabled for the database
+    if [[ "${DOLI_DB_SSL}" == "true" && "${DOLI_DB_TYPE}" == "mysqli"]]; then
+      echo "\$dolibarr_main_db_host='ssl://${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    else
+      echo "\$dolibarr_main_db_host='${DOLI_DB_HOST}';" >> /var/www/html/conf/conf.php
+    fi
+
+cat > /var/www/html/conf/conf.php << EOF
 \$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
 \$dolibarr_main_db_name='${DOLI_DB_NAME}';
 \$dolibarr_main_db_prefix='llx_';
@@ -69,6 +78,8 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 \$dolibarr_main_prod=${DOLI_PROD};
 EOF
+
+
     if [[ ! -z ${DOLI_INSTANCE_UNIQUE_ID} ]]; then
       echo "[INIT] => update Dolibarr Config with instance unique id ..."
       echo "\$dolibarr_main_instance_unique_id='${DOLI_INSTANCE_UNIQUE_ID}';" >> /var/www/html/conf/conf.php


### PR DESCRIPTION
This PR introduces the `DOLI_DB_SSL` variable which, when set to `true` (default), allows Dolibarr to securely connect to the MySQL database through an encrypted channel.