### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@
 # Instead perform any modifications in .github/build.yml.template
 
 name: build
+permissions:
+  contents: read
 on:
   # can run job manually
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Dolibarr/dolibarr-docker/security/code-scanning/4](https://github.com/Dolibarr/dolibarr-docker/security/code-scanning/4)

To fix the problem, you should explicitly set a `permissions` block in the workflow to restrict the default permissions granted to the GITHUB_TOKEN. The best approach is to add a top-level `permissions` key to the workflow, immediately after the `name:` declaration and before the `on:` block. This will apply to all jobs unless overridden at the job level. Since the jobs shown only require checking out the code and interacting with DockerHub (via secrets), the minimal permission, `contents: read`, is sufficient. No other permissions appear necessary.

**File/Region/Lines to change:**  
- Edit `.github/workflows/build.yml`.  
- Insert the following block after the `name: build` line, before `on:`.

No additional imports, method definitions, or variable changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
