### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
             - main
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     check-update:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Dolibarr/dolibarr-docker/security/code-scanning/3](https://github.com/Dolibarr/dolibarr-docker/security/code-scanning/3)

To fix the issue, we need to add an explicit `permissions` block to the workflow file. Since the `GITHUB_TOKEN` is required to perform certain operations (e.g., checking out the code), we will follow the principle of least privilege by limiting `contents` to `read` and granting additional permissions only where necessary. For this workflow, no write permissions are needed, so `contents: read` is sufficient.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that both `check-update` and `check-build` jobs inherit the same minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
