### PR TITLE
QUAL set AcceptPathInfo Off in Apache conf as recommended

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/18.0.9-php8.1/Dockerfile
+++ b/images/18.0.9-php8.1/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/21.0.4-php8.2/Dockerfile
+++ b/images/21.0.4-php8.2/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/22.0.4-php8.2/Dockerfile
+++ b/images/22.0.4-php8.2/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/23.0.2-php8.2/Dockerfile
+++ b/images/23.0.2-php8.2/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -91,6 +91,9 @@ RUN a2disconf serve-cgi-bin \
     -e 's/^\(ServerTokens\) OS$/\1 Prod/g' \
     /etc/apache2/conf-available/security.conf
 
+# Sets Apache AcceptPathInfo Off as recommended https://wiki.dolibarr.org/index.php/Security_information
+RUN echo "AcceptPathInfo Off" >> /etc/apache2/apache2.conf
+
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
     tar -C /tmp -xz && \


### PR DESCRIPTION
QUAL set AcceptPathInfo Off in Apache conf as recommended
Applying this PR would change the Dockerfile such that the image is built with Apache configuration that set `AcceptPathInfo Off` which is recommended by Dolibarr itself

https://wiki.dolibarr.org/index.php/Security_information

I tested this with hand changes in Dolibarrs official docker image for develop