### PR TITLE
QUAL set a sane open_basedir in php.ini

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/15.0.3-php7.4/Dockerfile
+++ b/images/15.0.3-php7.4/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/16.0.5-php8.1/Dockerfile
+++ b/images/16.0.5-php8.1/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/17.0.4-php8.1/Dockerfile
+++ b/images/17.0.4-php8.1/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/18.0.9-php8.1/Dockerfile
+++ b/images/18.0.9-php8.1/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/19.0.4-php8.2/Dockerfile
+++ b/images/19.0.4-php8.2/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/20.0.4-php8.2/Dockerfile
+++ b/images/20.0.4-php8.2/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/21.0.4-php8.2/Dockerfile
+++ b/images/21.0.4-php8.2/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/22.0.4-php8.2/Dockerfile
+++ b/images/22.0.4-php8.2/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/23.0.2-php8.2/Dockerfile
+++ b/images/23.0.2-php8.2/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -103,6 +103,8 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     chown -R www-data:www-data /var/www && \
     chmod -R u-w /var/www/html
 
+RUN echo 'open_basedir = "/var/www/html:/var/www/documents:/var/www/scripts:/tmp"' >> /usr/local/etc/php/php.ini
+
 EXPOSE 80
 VOLUME /var/www/documents
 VOLUME /var/www/html/custom


### PR DESCRIPTION
QUAL set a sane open_basedir in php.ini
Applying this PR will set open_basedir for Dolibarr in the php.ini file such that it is used by both apache and cron when the scripts/ are run.

Applying this PR will show up on this page /admin/system/security.php